### PR TITLE
Adapting to TE/JAX/CustiomPartitioning and Unify FP8 APIs with Native XLA Implementations

### DIFF
--- a/paxml/contrib/gpu/scripts_gpu/configs.py
+++ b/paxml/contrib/gpu/scripts_gpu/configs.py
@@ -166,15 +166,6 @@ class GPT126M(TransformerLmSpmdAdam):
       transformer_layer_p = stacked_p.transformer_layer_params_tpl
       transformer_layer_p.ln_tpl.reductions_in_fp32 = True
       transformer_layer_p.tr_fflayer_tpl.ln_tpl.reductions_in_fp32 = True
-    else:
-      stacked_p = TransformerEngineHelper.get_stack_transformer(
-        stacked_p, jnp.dtype(self.FPROP_DTYPE))
-      if issubclass(fdl.get_callable(model_p.lm_tpl.stacked_transformer_tpl),
-                    transformers.StackedTransformerRepeated):
-        model_p.lm_tpl.stacked_transformer_tpl.block = stacked_p
-      else:
-        model_p.lm_tpl.stacked_transformer_tpl = stacked_p
-
 
     model_p.params_init = WeightInit.Gaussian(self.INIT_STD)
     softmax_init = WeightInit.Gaussian(self.SOFTMAX_INIT_STD)

--- a/paxml/contrib/gpu/scripts_gpu/te_helper.py
+++ b/paxml/contrib/gpu/scripts_gpu/te_helper.py
@@ -1,13 +1,17 @@
 import os
 from contextlib import contextmanager
 
+from praxis import base_layer
+
 try:
   import transformer_engine.jax as te
   from transformer_engine.common import recipe
   _IS_TRANSFORMER_ENGINE_INSTALLED = True
+  DEFAULT_INIT_MUTABLE_LIST = base_layer.DEFAULT_INIT_MUTABLE_LIST + [te.fp8.FP8Helper.FP8_COLLECTION_NAME]
 
 except ModuleNotFoundError as e:
   _IS_TRANSFORMER_ENGINE_INSTALLED = False
+  DEFAULT_INIT_MUTABLE_LIST = base_layer.DEFAULT_INIT_MUTABLE_LIST
 
 
 class TransformerEngineHelperBase:

--- a/paxml/contrib/gpu/scripts_gpu/te_helper.py
+++ b/paxml/contrib/gpu/scripts_gpu/te_helper.py
@@ -1,237 +1,16 @@
 import os
 from contextlib import contextmanager
-from typing import Optional, Sequence
-
-import jax.numpy as jnp
-from jax.ad_checkpoint import checkpoint_name
-from praxis import base_layer
-from praxis import pax_fiddle
-from praxis import pytypes
-from praxis.layers import transformers
-from praxis.layers import stochastics
 
 try:
   import transformer_engine.jax as te
-  import transformer_engine.jax.flax as te_flax
-  import transformer_engine.jax.praxis as te_praxis
   from transformer_engine.common import recipe
   _IS_TRANSFORMER_ENGINE_INSTALLED = True
-  DEFAULT_INIT_MUTABLE_LIST = base_layer.DEFAULT_INIT_MUTABLE_LIST + [te.fp8.FP8Helper.FP8_COLLECTION_NAME]
-  import praxis.layers.repeats as praxis_repeat
-  # This is to make Repeat module correctly generate collections we need.
-  praxis_repeat.SCAN_VARIABLE_AXES.update({base_layer.NON_PAX_VAR_COLLECTION[1]: 0, # 1-idx = params_axes
-                                           te.fp8.FP8Helper.FP8_COLLECTION_NAME:0})
 
 except ModuleNotFoundError as e:
   _IS_TRANSFORMER_ENGINE_INSTALLED = False
-  DEFAULT_INIT_MUTABLE_LIST = base_layer.DEFAULT_INIT_MUTABLE_LIST
-
-
-LayerTpl = pax_fiddle.Config[base_layer.BaseLayer]
-JTensor = pytypes.JTensor
-
-
-class StackedTransformer(transformers.StackedTransformer):
-  """A mirror of StackedTransformer layers in Praxis."""
-
-  def setup(self) -> None:
-
-    assert self.num_layers > 0
-    assert self.model_dims > 0
-    assert self.hidden_dims > 0
-    assert self.num_heads > 0
-    assert 0.0 <= self.dropout_prob < 1.0
-    assert 0.0 <= self.input_dropout_prob < 1.0
-
-    def _layer_params(i):
-        """Construct i-th layer params."""
-        if isinstance(self.transformer_layer_params_tpl, Sequence):
-            factor = self.num_layers // len(self.transformer_layer_params_tpl)
-            ii = i // factor
-            p_i = self._clone_layer_params(self.transformer_layer_params_tpl[ii])
-        else:
-            p_i = self._clone_layer_params(self.transformer_layer_params_tpl)
-        p_i.name = f'layer_{i}'
-
-        p_i.logical_axes_rules = te_flax.extend_logical_axis_rules(tuple())
-        p_i.layer_type = te_praxis.TransformerLayerType.DECODER if self.use_cross_attention \
-                        else te_praxis.TransformerLayerType.ENCODER
-        p_i.num_attention_heads = self.num_heads
-        p_i.hidden_size = self.model_dims
-        p_i.mlp_hidden_size = self.hidden_dims
-
-        p_i.dropout_rng_name = base_layer.RANDOM
-        p_i.attention_dropout = self.atten_dropout_prob or self.dropout_prob
-        p_i.hidden_dropout = self.residual_dropout_prob or self.dropout_prob
-        p_i.intermediate_dropout = self.relu_dropout_prob or self.dropout_prob
-        if self.residual_droppath_prob > 0.0:
-            p_i.drop_path = (
-                self.residual_droppath_prob * i / max(1, self.num_layers)
-            )
-
-        assert self.dim_per_head == self.model_dims // self.num_heads
-        assert self.packed_input == False
-        assert len(self.moe_layers) == 0
-        assert self.ngrammer_tpls is None
-
-        if self.ngrammer_tpls is not None:
-            if self.ngrammer_tpls[i] is not None:
-                p_i.ngrammer_tpl = self.ngrammer_tpls[i]
-        return p_i
-
-    if isinstance(self.transformer_layer_params_tpl, (list, tuple)):
-        if self.num_layers % len(self.transformer_layer_params_tpl):
-            raise ValueError('num_layers should be divisible by '
-                                'transformer_layer_params_tpl')
-
-    layer_params = [_layer_params(i) for i in range(self.num_layers)]
-    self.create_children('x_layers', layer_params)
-
-    if self.input_dropout_prob > 0.0:
-        self.create_child(
-            'input_dropout',
-            pax_fiddle.Config(
-                  stochastics.Dropout, keep_prob=1.0 - self.input_dropout_prob
-            ),
-        )
-
-  def __call__(self,
-               inputs: JTensor,
-               paddings: JTensor,
-               segment_mask: Optional[JTensor] = None,
-               cross_inputs: Optional[JTensor] = None,
-               cross_paddings: Optional[JTensor] = None,
-               cross_segment_mask: Optional[JTensor] = None,
-               segment_pos: Optional[JTensor] = None) -> JTensor:
-
-    if self.packed_input:
-        assert segment_mask is not None
-
-    if self.use_cross_attention:
-        assert cross_inputs is not None
-        assert cross_paddings is not None
-        if self.packed_input:
-            assert cross_segment_mask is not None
-
-    attention_mask, cross_attention_mask = transformers.compute_attention_masks_for_fprop(
-        inputs,
-        paddings,
-        self.mask_self_attention,
-        segment_mask,
-        cross_inputs,
-        cross_paddings,
-        cross_segment_mask,
-        fold_padding_with_segment_mask=self.fold_padding_with_segment_mask,
-    )
-
-    x_out = inputs
-    if self.input_dropout_prob > 0.0:
-        x_out = self.input_dropout(x_out)
-
-    attention_mask = 1 - (attention_mask == 0)
-    attention_mask = attention_mask.astype(jnp.uint8)
-
-    if cross_attention_mask is not None:
-        cross_attention_mask = 1 - (cross_attention_mask == 0)
-        cross_attention_mask = cross_attention_mask.astype(jnp.uint8)
-
-    for i in range(self.num_layers):
-        x_in = x_out
-        x_out = self.x_layers[i](
-            inputs=x_in,
-            attention_mask=attention_mask,
-            encoded=cross_inputs,
-            encoder_decoder_mask=cross_attention_mask,
-            deterministic=self.do_eval)
-        x_out = checkpoint_name(x_out, 'transformer_layer_out')
-    return x_out
-
-
-class PipelinedTransformer(transformers.PipelinedTransformer):
-    """A mirror of PipelinedTransformer in Praxis"""
-
-    def __call__(
-        self,
-        inputs: JTensor,
-        paddings: JTensor,
-        segment_mask: JTensor | None = None,
-        cross_inputs: JTensor | None = None,
-        cross_paddings: JTensor | None = None,
-        cross_segment_mask: JTensor | None = None,
-        segment_pos: JTensor | None = None,
-    ) -> JTensor:
-
-        rules = te_flax.extend_logical_axis_rules(tuple())
-        batch_mapping = rules[0]
-        hidden_tp_mapping = rules[4]
-        # [Batch, Seqlen, Hidden]
-        bld_mapping = [batch_mapping, None, hidden_tp_mapping]
-
-        if not self.stream_io:
-            # Annotate the inputs before the pipeline to prevent unexpected
-            # propagation from earlier layers.
-            inputs = base_layer.maybe_shard(inputs, bld_mapping, self.mesh_axis_names)
-            if bld_mapping is not None:
-                # Annotate other broadcast inputs.
-                paddings = base_layer.maybe_shard(
-                    paddings, bld_mapping[:-1], self.mesh_axis_names
-                )
-
-                # For cross inputs, we only specify the batch dim sharding.
-                def _shard_batch_dim_only(x):
-                    return base_layer.maybe_shard(
-                        x,
-                        [bld_mapping[0]] + [-1] * (x.ndim - 1),
-                        self.mesh_axis_names,
-                        unconstrained_dims=range(1, x.ndim),
-                    )
-
-                if segment_mask is not None:
-                    segment_mask = _shard_batch_dim_only(segment_mask)
-                if cross_inputs is not None:
-                    cross_inputs = _shard_batch_dim_only(cross_inputs)
-                if cross_paddings is not None:
-                    cross_paddings = _shard_batch_dim_only(cross_paddings)
-                if cross_segment_mask is not None:
-                    cross_segment_mask = _shard_batch_dim_only(cross_segment_mask)
-
-                if segment_pos is not None:
-                    segment_pos = base_layer.maybe_shard(
-                        segment_pos, bld_mapping[:-1], self.mesh_axis_names
-                    )
-
-        outputs = self.pipeline(
-            inputs,
-            paddings,
-            segment_mask=segment_mask,
-            cross_inputs=cross_inputs,
-            cross_paddings=cross_paddings,
-            cross_segment_mask=cross_segment_mask,
-            segment_pos=segment_pos,
-        )
-
-        if not self.stream_io:
-            outputs = base_layer.maybe_shard(
-                outputs, bld_mapping, self.mesh_axis_names
-            )
-
-        outputs = base_layer.maybe_shard(
-            outputs,
-            self.activation_split_dims_mapping.final_out,
-            self.mesh_axis_names,
-        )
-        return outputs
 
 
 class TransformerEngineHelperBase:
-
-    @staticmethod
-    def get_stack_transformer(stacked_transformer_p, dtype):
-        raise NotImplementedError
-
-    @staticmethod
-    def get_pipeline_transformer(pipeline_transformer_p):
-        raise NotImplementedError
 
     @staticmethod
     @contextmanager
@@ -240,14 +19,6 @@ class TransformerEngineHelperBase:
 
 
 class TENotInstalledHelper(TransformerEngineHelperBase):
-
-    @staticmethod
-    def get_stack_transformer(stacked_transformer_p, dtype):
-        return stacked_transformer_p
-
-    @staticmethod
-    def get_pipeline_transformer(pipeline_transformer_p):
-        return pipeline_transformer_p
 
     @staticmethod
     @contextmanager
@@ -259,84 +30,6 @@ class TENotInstalledHelper(TransformerEngineHelperBase):
 
 
 class TEInstalledHelper(TransformerEngineHelperBase):
-
-    @staticmethod
-    def get_stack_transformer(stacked_transformer_p, dtype):
-
-        assert stacked_transformer_p.cls == transformers.StackedTransformer
-
-        te_stacked_transformer_p = pax_fiddle.Config(StackedTransformer,
-            use_cross_attention=stacked_transformer_p.use_cross_attention,
-            mask_self_attention=stacked_transformer_p.mask_self_attention,
-            num_layers=stacked_transformer_p.num_layers,
-            model_dims=stacked_transformer_p.model_dims,
-            hidden_dims=stacked_transformer_p.hidden_dims,
-            num_heads=stacked_transformer_p.num_heads,
-            dim_per_head=stacked_transformer_p.dim_per_head,
-            dropout_prob=stacked_transformer_p.dropout_prob,
-            atten_dropout_prob=stacked_transformer_p.atten_dropout_prob,
-            residual_dropout_prob=stacked_transformer_p.residual_dropout_prob,
-            relu_dropout_prob=stacked_transformer_p.relu_dropout_prob,
-            residual_droppath_prob=stacked_transformer_p.residual_droppath_prob,
-            input_dropout_prob=stacked_transformer_p.input_dropout_prob,
-            gating_func=stacked_transformer_p.gating_func,
-            unadjusted_expert_capacity_factor=stacked_transformer_p.unadjusted_expert_capacity_factor,
-            packed_input=stacked_transformer_p.packed_input,
-            fold_padding_with_segment_mask=stacked_transformer_p.fold_padding_with_segment_mask,
-            moe_layer_tpl=stacked_transformer_p.moe_layer_tpl,
-            num_experts=stacked_transformer_p.num_experts,
-            num_groups=stacked_transformer_p.num_groups,
-            min_group_size=stacked_transformer_p.min_group_size,
-            moe_layers=stacked_transformer_p.moe_layers,
-            ngrammer_tpls=stacked_transformer_p.ngrammer_tpls
-        )
-
-        ori_transformer_engine_p = stacked_transformer_p.transformer_layer_params_tpl
-
-        te_stacked_transformer_p.transformer_layer_params_tpl = pax_fiddle.Config(te_praxis.TransformerLayer,
-            name='transformer_layer',
-            params_init=stacked_transformer_p.params_init,
-            dtype=dtype,
-            hidden_size=stacked_transformer_p.model_dims,
-            mlp_hidden_size=stacked_transformer_p.hidden_dims,
-            num_attention_heads=stacked_transformer_p.num_heads,
-            layernorm_type='layernorm',
-            layernorm_epsilon=ori_transformer_engine_p.ln_tpl.epsilon,
-            zero_centered_gamma = True,
-            hidden_dropout=ori_transformer_engine_p.residual_dropout_prob,
-            attention_dropout=ori_transformer_engine_p.atten_dropout_prob,
-            mlp_activations=('gelu',),
-            use_bias=True,
-            layer_type=te_praxis.TransformerLayerType.ENCODER,
-            self_attn_mask_type='causal',
-            enable_relative_embedding=False,
-            drop_path=ori_transformer_engine_p.residual_droppath_prob,
-            scaled_query_init=False,
-            scale_attn_logits=True,
-            transpose_batch_sequence=False
-        )
-
-        return te_stacked_transformer_p
-
-    @staticmethod
-    def get_pipeline_transformer(pipeline_transformer_p):
-
-        assert pipeline_transformer_p.cls == transformers.PipelinedTransformer
-
-        te_pipeline_transformer_p = pax_fiddle.Config(PipelinedTransformer,
-            pipeline_stage=pipeline_transformer_p.pipeline_stage,
-            circular_repeat=pipeline_transformer_p.circular_repeat,
-            num_pipeline_stages=pipeline_transformer_p.num_pipeline_stages,
-            num_pipeline_microbatches=pipeline_transformer_p.num_pipeline_microbatches,
-            pipeline_microbatch_size=pipeline_transformer_p.pipeline_microbatch_size,
-            stream_io=pipeline_transformer_p.stream_io,
-            pipeline_broadcast_inputs=pipeline_transformer_p.pipeline_broadcast_inputs,
-            checkpoint_policy=pipeline_transformer_p.checkpoint_policy,
-            enable_async_circular_transfer=pipeline_transformer_p.enable_async_circular_transfer,
-            bf16_accum_in_fp32=pipeline_transformer_p.bf16_accum_in_fp32
-        )
-
-        return te_pipeline_transformer_p
 
     @staticmethod
     @contextmanager
@@ -368,14 +61,6 @@ class TransformerEngineHelper(TransformerEngineHelperBase):
         if TransformerEngineHelper.is_enabled_te():
             return TEInstalledHelper
         return TENotInstalledHelper
-
-    @staticmethod
-    def get_stack_transformer(stacked_transformer_p, dtype):
-        return TransformerEngineHelper.get_helper().get_stack_transformer(stacked_transformer_p, dtype)
-
-    @staticmethod
-    def get_pipeline_transformer(pipeline_transformer_p):
-        return TransformerEngineHelper.get_helper().get_pipeline_transformer(pipeline_transformer_p)
 
     @staticmethod
     @contextmanager

--- a/paxml/contrib/gpu/scripts_gpu/te_helper.py
+++ b/paxml/contrib/gpu/scripts_gpu/te_helper.py
@@ -262,7 +262,7 @@ class TEInstalledHelper(TransformerEngineHelperBase):
     def update_fp8_metas_if_needed(mdl_vars, grads):
         FP8_COLLECTION_NAME = te.fp8.FP8Helper.FP8_COLLECTION_NAME
         if FP8_COLLECTION_NAME in grads:
-            mdl_vars[FP8_COLLECTION_NAME] = te.update_fp8_metas(grads)[FP8_COLLECTION_NAME]
+            mdl_vars[FP8_COLLECTION_NAME] = grads[FP8_COLLECTION_NAME]
         return mdl_vars
 
     @staticmethod
@@ -290,7 +290,9 @@ class TEInstalledHelper(TransformerEngineHelperBase):
         try:
             with te.fp8_autocast(enabled=enable_fp8,
                                  fp8_recipe=fp8_recipe,
-                                 sharding_resource=te.ShardingResource(dp_mesh_axis, tp_mesh_axis, fsdp_mesh_axis)):
+                                 mesh_resource=te.MeshResource(dp_resource=dp_mesh_axis,
+                                                               tp_resource=tp_mesh_axis,
+                                                               fsdp_resource=fsdp_mesh_axis)):
                 yield
         finally:
             pass

--- a/paxml/trainer_lib.py
+++ b/paxml/trainer_lib.py
@@ -995,16 +995,15 @@ def get_excluded_var_masks(
   excluded_for_grad = tasks_lib.get_excluded_var_mask_for_grad(
       var_weight_hparams, learner
   )
-  excluded_for_grad_but_fp8_meta = TransformerEngineHelper.include_fp8_for_grads_if_needed(excluded_for_grad.copy())
 
-  _log_bprop_include_exclude_list(var_weight_hparams, excluded_for_grad_but_fp8_meta)
+  _log_bprop_include_exclude_list(var_weight_hparams, excluded_for_grad)
 
   # Excluded for optimizer states.
   excluded_for_opt = tasks_lib.get_excluded_var_mask_for_opt(
       var_weight_hparams,
       learner,
   )
-  return excluded_for_grad, excluded_for_grad_but_fp8_meta, excluded_for_opt
+  return excluded_for_grad, excluded_for_opt
 
 
 # TODO(yonghui): refactor to pass in learner separately.
@@ -1080,13 +1079,13 @@ def train_step_single_learner(
 
   _, subkey = jax.random.split(prng_key)
 
-  excluded_for_grad, excluded_for_grad_but_fp8_meta, excluded_for_opt = get_excluded_var_masks(
+  excluded_for_grad, excluded_for_opt = get_excluded_var_masks(
       var_weight_hparams, learner
   )
 
   # Construct and call the grad function.
   if not grad_fn:
-    grad_fn = _get_default_grad_fn(excluded_for_grad_but_fp8_meta, excluded_for_opt)
+    grad_fn = _get_default_grad_fn(excluded_for_grad, excluded_for_opt)
   (weighted_loss, aux_info), grads = grad_fn(
       loss_fn=_get_default_loss_fn(
           jax_task=jax_task,
@@ -1142,9 +1141,6 @@ def train_step_single_learner(
     wps_with_opt = tasks_lib.filter_vars_for_grad_or_opt(
         var_weight_hparams, excluded_for_learner
     )
-
-    mdl_vars = TransformerEngineHelper.update_fp8_metas_if_needed(mdl_vars, grads)
-    grads = TransformerEngineHelper.mask_out_fp8_meta_grads_if_needed(grads, vars_with_opt)
 
     transformed_grads, new_opt_states = learner.update_states(
         grads, states.opt_states[0], vars_with_opt, wps_with_opt


### PR DESCRIPTION
- Renaming ShardingResource to MeshResource.
- Removing manually invocation of the.update_fp8_metas, since TE already hides those updates into the backward phase.
- Applying OWG to TE's fp8 meta collection. REQUIRED Praxis with [PR-29](https://github.com/google/praxis/pull/29) and Paxml with [PR-48](https://github.com/google/paxml/pull/48).
- Refer to [TE-PR472](https://github.com/NVIDIA/TransformerEngine/pull/472) for details.
- Removing Praxis related setup. Those are moved in to [Praxis/TE/Patch](https://github.com/nvjax-svc-0/praxis/tree/mingh/te_support)