### PR TITLE
Extend checkpoint_policy and remat propagation to StackedTransformer

### DIFF
--- a/paxml/contrib/gpu/scripts_gpu/configs.py
+++ b/paxml/contrib/gpu/scripts_gpu/configs.py
@@ -74,6 +74,8 @@ def configure_gpt3_task(
       fdl.get_callable(stacked_p), transformers.StackedTransformerRepeated
   ):
     stacked_p = stacked_p.block
+  stacked_p.checkpoint_policy = cls.CHECKPOINT_POLICY
+  stacked_p.remat = cls.USE_REPEATED_LAYER
   transformer_layer_p = stacked_p.transformer_layer_params_tpl
 
   transformer_layer_p.ln_tpl.epsilon = cls.LAYERNORM_EPSILON


### PR DESCRIPTION
Currently, the `checkpoint policy` and `remat` configs are only propagated to the [StackedTransformerRepeated](https://github.com/nvjax-svc-0/paxml/blob/patch/te_support/paxml/tasks/lm/model_params.py#L846C1-L846C73) and they are not propagated to the `StackedTransformer`.

However, TE will add a checkpoint policy check recently, and TE will need both of them to be propagated to `StackedTransformer` since TE [parses the StackedTransformer](https://github.com/nvjax-svc-0/praxis/blob/mingh/te_support/praxis/contrib/gpu/scripts_gpu/te_helper.py#L104-L141) instead of `StackedTransformerRepeat`. Therefore, this PR is to propagate the `checkpoint_policy` and `remat` configs from `StackedTransformerRepeated` to `StackedTransformer`.