### PR TITLE
Revert mutable kwarg in abstract_init_with_metadata in init checkpoint rule

### DIFF
--- a/paxml/tasks_lib.py
+++ b/paxml/tasks_lib.py
@@ -1787,7 +1787,7 @@ class SingleTask(base_task.BaseTask):
       )
     # Initialize with a dummy seed
     var_weight_hparams = ckpt_task.model.abstract_init_with_metadata(
-        inputs_shape_dtype, mutable=DEFAULT_INIT_MUTABLE_LIST)
+        inputs_shape_dtype, extra_mutable_list=DEFAULT_INIT_MUTABLE_LIST)
     ckpt_train_state = ckpt_task.create_train_state_padded_shapes(
         var_weight_hparams)
     train_state_pspecs = ckpt_task.create_train_state_partition_specs(


### PR DESCRIPTION
[abstract_init_with_metadata](https://github.com/google/praxis/blob/bfc7a0ed1e65ffedab5e7bdaac85a28ee51566b3/praxis/base_layer.py#L2033) takes in `extra_mutable_list` as the kwarg for specifying the mutable list.

This kwarg is already used in other places in the TE patch. See [here](https://github.com/nvjax-svc-0/paxml/pull/2/files#diff-4519e325826116a98257dbd6421a26c98616b3afc5310b982cf25858853a7381R171) for example.

This PR amends the `apply_init_checkpoint_rule` method to correctly use the `extra_mutable_list` kwarg. 

Tested on an FP8 checkpoint